### PR TITLE
Initial Implementation + Test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,6 @@
-# references:
-# * http://www.objc.io/issue-6/travis-ci.html
-# * https://github.com/supermarin/xcpretty#usage
-
 language: objective-c
-# cache: cocoapods
-# podfile: Example/Podfile
-# before_install:
-# - gem install cocoapods # Since Travis is not always on latest version
-# - pod install --project-directory=Example
-install:
-- gem install xcpretty --no-rdoc --no-ri --no-document --quiet
-script:
-- set -o pipefail && xcodebuild test -workspace Example/VOKEmbeddedTemplateTools.xcworkspace -scheme VOKEmbeddedTemplateTools -sdk macosx10.9 ONLY_ACTIVE_ARCH=NO | xcpretty -c
-- pod lib lint --quick
+xcode_workspace: Example/VOKEmbeddedTemplateTools.xcworkspace
+xcode_scheme: VOKEmbeddedTemplateTools
+xcode_sdk: macosx10.9
+after_success:
+    - pod lib lint --quick

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ language: objective-c
 install:
 - gem install xcpretty --no-rdoc --no-ri --no-document --quiet
 script:
-- set -o pipefail && xcodebuild test -workspace Example/VOKEmbeddedTemplateTools.xcworkspace -scheme VOKEmbeddedTemplateTools-Example -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO | xcpretty -c
+- set -o pipefail && xcodebuild test -workspace Example/VOKEmbeddedTemplateTools.xcworkspace -scheme VOKEmbeddedTemplateTools -sdk macosx10.9 ONLY_ACTIVE_ARCH=NO | xcpretty -c
 - pod lib lint --quick

--- a/Example/VOKEmbeddedTemplateTools.xcodeproj/project.pbxproj
+++ b/Example/VOKEmbeddedTemplateTools.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		71FBF7B11B80E21200AF04D8 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 71FBF7B01B80E21200AF04D8 /* Images.xcassets */; };
 		71FBF7B41B80E21200AF04D8 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 71FBF7B21B80E21200AF04D8 /* MainMenu.xib */; };
 		71FBF7C01B80E21200AF04D8 /* VOKEmbeddedTemplateToolsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 71FBF7BF1B80E21200AF04D8 /* VOKEmbeddedTemplateToolsTests.m */; };
+		71FBF7D01B81873E00AF04D8 /* test.mustache in Resources */ = {isa = PBXBuildFile; fileRef = 71FBF7CD1B81869300AF04D8 /* test.mustache */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -43,6 +44,7 @@
 		71FBF7CA1B80E3A000AF04D8 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		71FBF7CB1B80E3A000AF04D8 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		71FBF7CC1B80E3A000AF04D8 /* VOKEmbeddedTemplateTools.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; name = VOKEmbeddedTemplateTools.podspec; path = ../VOKEmbeddedTemplateTools.podspec; sourceTree = "<group>"; };
+		71FBF7CD1B81869300AF04D8 /* test.mustache */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = test.mustache; sourceTree = "<group>"; };
 		7706153C8EAA852B25204B8B /* Pods-VOKEmbeddedTemplateTools.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VOKEmbeddedTemplateTools.debug.xcconfig"; path = "Pods/Target Support Files/Pods-VOKEmbeddedTemplateTools/Pods-VOKEmbeddedTemplateTools.debug.xcconfig"; sourceTree = "<group>"; };
 		8D684BE2722C80EE005933EC /* Pods-VOKEmbeddedTemplateToolsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VOKEmbeddedTemplateToolsTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-VOKEmbeddedTemplateToolsTests/Pods-VOKEmbeddedTemplateToolsTests.release.xcconfig"; sourceTree = "<group>"; };
 		9E8AF94E020F17D6512EA679 /* libPods-VOKEmbeddedTemplateTools.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-VOKEmbeddedTemplateTools.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -115,6 +117,7 @@
 			children = (
 				71FBF7BF1B80E21200AF04D8 /* VOKEmbeddedTemplateToolsTests.m */,
 				71FBF7BD1B80E21200AF04D8 /* Supporting Files */,
+				71FBF7CD1B81869300AF04D8 /* test.mustache */,
 			);
 			path = VOKEmbeddedTemplateToolsTests;
 			sourceTree = "<group>";
@@ -165,6 +168,7 @@
 			buildConfigurationList = 71FBF7C31B80E21200AF04D8 /* Build configuration list for PBXNativeTarget "VOKEmbeddedTemplateTools" */;
 			buildPhases = (
 				AD415DB1CA553A29B16A84CD /* Check Pods Manifest.lock */,
+				71FBF7CF1B8186AE00AF04D8 /* Make test template zip */,
 				71FBF7A21B80E21200AF04D8 /* Sources */,
 				71FBF7A31B80E21200AF04D8 /* Frameworks */,
 				71FBF7A41B80E21200AF04D8 /* Resources */,
@@ -250,6 +254,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				71FBF7D01B81873E00AF04D8 /* test.mustache in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -300,6 +305,20 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-VOKEmbeddedTemplateTools/Pods-VOKEmbeddedTemplateTools-resources.sh\"\n";
 			showEnvVarsInLog = 0;
+		};
+		71FBF7CF1B8186AE00AF04D8 /* Make test template zip */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Make test template zip";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "ditto -ck \"${SRCROOT}/VOKEmbeddedTemplateToolsTests/test.mustache\" \"${TARGET_BUILD_DIR}/template.zip\" || exit 1";
 		};
 		AD415DB1CA553A29B16A84CD /* Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -442,6 +461,13 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = VOKEmbeddedTemplateTools/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-sectcreate",
+					__TEXT,
+					__test_zip,
+					"\"${TARGET_BUILD_DIR}/template.zip\"",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -454,6 +480,13 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = VOKEmbeddedTemplateTools/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-sectcreate",
+					__TEXT,
+					__test_zip,
+					"\"${TARGET_BUILD_DIR}/template.zip\"",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/Example/VOKEmbeddedTemplateTools.xcodeproj/project.pbxproj
+++ b/Example/VOKEmbeddedTemplateTools.xcodeproj/project.pbxproj
@@ -415,6 +415,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
+				VOK_EMBEDDED_ZIP_SECTION = __test_zip;
 			};
 			name = Debug;
 		};
@@ -450,6 +451,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
+				VOK_EMBEDDED_ZIP_SECTION = __test_zip;
 			};
 			name = Release;
 		};
@@ -465,7 +467,7 @@
 					"$(inherited)",
 					"-sectcreate",
 					__TEXT,
-					__test_zip,
+					"\"${VOK_EMBEDDED_ZIP_SECTION}\"",
 					"\"${TARGET_BUILD_DIR}/template.zip\"",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -484,7 +486,7 @@
 					"$(inherited)",
 					"-sectcreate",
 					__TEXT,
-					__test_zip,
+					"\"${VOK_EMBEDDED_ZIP_SECTION}\"",
 					"\"${TARGET_BUILD_DIR}/template.zip\"",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -502,8 +504,8 @@
 					"$(inherited)",
 				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
 					"$(inherited)",
+					"VOK_EMBEDDED_ZIP_SECTION='@\"'\"${VOK_EMBEDDED_ZIP_SECTION}\"'\"'",
 				);
 				INFOPLIST_FILE = VOKEmbeddedTemplateToolsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
@@ -521,6 +523,10 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 					"$(inherited)",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"VOK_EMBEDDED_ZIP_SECTION='@\"'\"${VOK_EMBEDDED_ZIP_SECTION}\"'\"'",
 				);
 				INFOPLIST_FILE = VOKEmbeddedTemplateToolsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";

--- a/Example/VOKEmbeddedTemplateTools.xcodeproj/xcshareddata/xcschemes/VOKEmbeddedTemplateTools.xcscheme
+++ b/Example/VOKEmbeddedTemplateTools.xcodeproj/xcshareddata/xcschemes/VOKEmbeddedTemplateTools.xcscheme
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0620"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "71FBF7A51B80E21200AF04D8"
+               BuildableName = "VOKEmbeddedTemplateTools.app"
+               BlueprintName = "VOKEmbeddedTemplateTools"
+               ReferencedContainer = "container:VOKEmbeddedTemplateTools.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "71FBF7B81B80E21200AF04D8"
+               BuildableName = "VOKEmbeddedTemplateToolsTests.xctest"
+               BlueprintName = "VOKEmbeddedTemplateToolsTests"
+               ReferencedContainer = "container:VOKEmbeddedTemplateTools.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "71FBF7B81B80E21200AF04D8"
+               BuildableName = "VOKEmbeddedTemplateToolsTests.xctest"
+               BlueprintName = "VOKEmbeddedTemplateToolsTests"
+               ReferencedContainer = "container:VOKEmbeddedTemplateTools.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "71FBF7A51B80E21200AF04D8"
+            BuildableName = "VOKEmbeddedTemplateTools.app"
+            BlueprintName = "VOKEmbeddedTemplateTools"
+            ReferencedContainer = "container:VOKEmbeddedTemplateTools.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "71FBF7A51B80E21200AF04D8"
+            BuildableName = "VOKEmbeddedTemplateTools.app"
+            BlueprintName = "VOKEmbeddedTemplateTools"
+            ReferencedContainer = "container:VOKEmbeddedTemplateTools.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "71FBF7A51B80E21200AF04D8"
+            BuildableName = "VOKEmbeddedTemplateTools.app"
+            BlueprintName = "VOKEmbeddedTemplateTools"
+            ReferencedContainer = "container:VOKEmbeddedTemplateTools.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Example/VOKEmbeddedTemplateToolsTests/VOKEmbeddedTemplateToolsTests.m
+++ b/Example/VOKEmbeddedTemplateToolsTests/VOKEmbeddedTemplateToolsTests.m
@@ -22,7 +22,7 @@
 - (void)testExample
 {
     NSError *error;
-    ZZArchive *archive = [ZZArchive vok_archiveFromMachOSection:@"__test_zip"
+    ZZArchive *archive = [ZZArchive vok_archiveFromMachOSection:VOK_EMBEDDED_ZIP_SECTION
                                                           error:&error];
     XCTAssertNotNil(archive);
     XCTAssertNil(error);

--- a/Example/VOKEmbeddedTemplateToolsTests/VOKEmbeddedTemplateToolsTests.m
+++ b/Example/VOKEmbeddedTemplateToolsTests/VOKEmbeddedTemplateToolsTests.m
@@ -9,32 +9,44 @@
 #import <Cocoa/Cocoa.h>
 #import <XCTest/XCTest.h>
 
+#import <GRMustache.h>
+#import <VOKZZArchiveTemplateRepository.h>
+#import <ZZArchive+VOKMachOEmbedded.h>
+
 @interface VOKEmbeddedTemplateToolsTests : XCTestCase
 
 @end
 
 @implementation VOKEmbeddedTemplateToolsTests
 
-- (void)setUp {
-    [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-}
-
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-    [super tearDown];
-}
-
-- (void)testExample {
-    // This is an example of a functional test case.
-    XCTAssert(YES, @"Pass");
-}
-
-- (void)testPerformanceExample {
-    // This is an example of a performance test case.
-    [self measureBlock:^{
-        // Put the code you want to measure the time of here.
-    }];
+- (void)testExample
+{
+    NSError *error;
+    ZZArchive *archive = [ZZArchive vok_archiveFromMachOSection:@"__test_zip"
+                                                          error:&error];
+    XCTAssertNotNil(archive);
+    XCTAssertNil(error);
+    
+    VOKZZArchiveTemplateRepository *templateRepo = [VOKZZArchiveTemplateRepository templateRepositoryWithArchive:archive];
+    XCTAssertNotNil(templateRepo);
+    
+    GRMustacheTemplate *template = [templateRepo templateNamed:@"test" error:&error];
+    XCTAssertNotNil(template);
+    XCTAssertNil(error);
+    
+    NSString *result = [template renderObject:nil error:&error];
+    XCTAssertNotNil(result);
+    XCTAssertNil(error);
+    
+    NSString *expectedResult = [NSString stringWithContentsOfURL:[[NSBundle bundleForClass:[self class]]
+                                                                  URLForResource:@"test"
+                                                                  withExtension:@"mustache"]
+                                                        encoding:NSUTF8StringEncoding
+                                                           error:&error];
+    XCTAssertNotNil(expectedResult);
+    XCTAssertNil(error);
+    
+    XCTAssertEqualObjects(result, expectedResult);
 }
 
 @end

--- a/Example/VOKEmbeddedTemplateToolsTests/test.mustache
+++ b/Example/VOKEmbeddedTemplateToolsTests/test.mustache
@@ -1,0 +1,1 @@
+This is a test.

--- a/Pod/NSData+VOKMachOEmbedded.h
+++ b/Pod/NSData+VOKMachOEmbedded.h
@@ -1,0 +1,24 @@
+//
+//  NSData+VOKMachOEmbedded.h
+//  VOKEmbeddedTemplateTools
+//
+//  Created by Isaac Greenspan on 8/16/15.
+//  Copyright (c) 2015 Vokal. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSData (VOKMachOEmbedded)
+
+/**
+ *  Get data embedded into the currently-running mach-o executable.
+ *
+ *  @param sectionName The name of the section inside the __TEXT segment in which to find the data.
+ *  @param error       The error information when an error occurs.
+ *
+ *  @return The embedded data.
+ */
++ (instancetype)vok_dataFromMachOSection:(NSString *)sectionName
+                                   error:(NSError **)error;
+
+@end

--- a/Pod/NSData+VOKMachOEmbedded.m
+++ b/Pod/NSData+VOKMachOEmbedded.m
@@ -1,0 +1,29 @@
+//
+//  NSData+VOKMachOEmbedded.m
+//  VOKEmbeddedTemplateTools
+//
+//  Created by Isaac Greenspan on 8/16/15.
+//  Copyright (c) 2015 Vokal. All rights reserved.
+//
+
+#import "NSData+VOKMachOEmbedded.h"
+
+#import <mach-o/getsect.h>
+#import <mach-o/ldsyms.h>
+
+@implementation NSData (VOKMachOEmbedded)
+
++ (instancetype)vok_dataFromMachOSection:(NSString *)sectionName
+                                   error:(NSError **)error
+{
+    // Extract the raw bytes of the given section of the __TEXT segment of the currently-running mach-o executable.
+    unsigned long size;
+    void *ptr = getsectiondata(&_mh_execute_header, "__TEXT", sectionName.UTF8String, &size);
+    
+    // Wrap those bytes in an NSData object.
+    return [self dataWithBytesNoCopy:ptr
+                              length:size
+                        freeWhenDone:NO];
+}
+
+@end

--- a/Pod/VOKZZArchiveTemplateRepository.h
+++ b/Pod/VOKZZArchiveTemplateRepository.h
@@ -1,0 +1,18 @@
+//
+//  VOKZZArchiveTemplateRepository.h
+//  VOKEmbeddedTemplateTools
+//
+//  Created by Isaac Greenspan on 8/16/15.
+//  Copyright (c) 2015 Vokal. All rights reserved.
+//
+
+#import "GRMustacheTemplateRepository.h"
+
+@class ZZArchive;
+
+@interface VOKZZArchiveTemplateRepository : GRMustacheTemplateRepository
+
++ (instancetype)templateRepositoryWithArchive:(ZZArchive *)archive;
+- (instancetype)initWithArchive:(ZZArchive *)archive;
+
+@end

--- a/Pod/VOKZZArchiveTemplateRepository.m
+++ b/Pod/VOKZZArchiveTemplateRepository.m
@@ -1,0 +1,73 @@
+//
+//  VOKZZArchiveTemplateRepository.m
+//  VOKEmbeddedTemplateTools
+//
+//  Created by Isaac Greenspan on 8/16/15.
+//  Copyright (c) 2015 Vokal. All rights reserved.
+//
+
+#import "VOKZZArchiveTemplateRepository.h"
+
+#import <ZipZap.h>
+
+@interface VOKZZArchiveTemplateRepository () <GRMustacheTemplateRepositoryDataSource>
+
+@property (nonatomic, strong) ZZArchive *archive;
+
+@end
+
+@implementation VOKZZArchiveTemplateRepository
+
++ (instancetype)templateRepositoryWithArchive:(ZZArchive *)archive
+{
+    return [[self alloc] initWithArchive:archive];
+}
+
+- (instancetype)initWithArchive:(ZZArchive *)archive
+{
+    self = [super init];
+    if (self) {
+        _archive = archive;
+        self.dataSource = self;
+    }
+    return self;
+}
+
+#pragma mark - GRMustacheTemplateRepositoryDataSource
+
+- (NSString *)templateRepository:(GRMustacheTemplateRepository *)templateRepository
+     templateStringForTemplateID:(id)templateID
+                           error:(NSError **)error
+{
+    NSUInteger index = [self.archive.entries indexOfObjectPassingTest:^BOOL(ZZArchiveEntry *entry, NSUInteger idx, BOOL *stop) {
+        return [entry.fileName isEqualToString:templateID];
+    }];
+    if (index == NSNotFound) {
+        // No need to return an error.
+        // GRMustacheTemplateRepository will construct a generic "template not found" error, which makes sense here.
+        return nil;
+    }
+    ZZArchiveEntry *entry = self.archive.entries[index];
+    NSData *data = [entry newDataWithError:error];
+    if (!data) {
+        return nil;
+    }
+    return [[NSString alloc] initWithData:data
+                                 encoding:NSUTF8StringEncoding];
+}
+
+- (id<NSCopying>)templateRepository:(GRMustacheTemplateRepository *)templateRepository
+                  templateIDForName:(NSString *)name
+               relativeToTemplateID:(id)baseTemplateID
+{
+    // Rebase template names starting with a /
+    if ([name characterAtIndex:0] == '/') {
+        name = [name substringFromIndex:1];
+        baseTemplateID = nil;
+    }
+    
+    NSString *relativePath = [baseTemplateID ?: @"" stringByDeletingLastPathComponent];
+    return [[relativePath stringByAppendingPathComponent:name] stringByAppendingPathExtension:@"mustache"];
+}
+
+@end

--- a/Pod/ZZArchive+VOKMachOEmbedded.h
+++ b/Pod/ZZArchive+VOKMachOEmbedded.h
@@ -1,0 +1,24 @@
+//
+//  ZZArchive+VOKMachOEmbedded.h
+//  VOKEmbeddedTemplateTools
+//
+//  Created by Isaac Greenspan on 8/16/15.
+//  Copyright (c) 2015 Vokal. All rights reserved.
+//
+
+#import "ZZArchive.h"
+
+@interface ZZArchive (VOKMachOEmbedded)
+
+/**
+ *  Create a new archive from zip data embedded into the currently-running mach-o executable.
+ *
+ *  @param sectionName The name of the section inside the __TEXT segment in which to find the zip data.
+ *  @param error       The error information when an error occurs.
+ *
+ *  @return The initialized archive.
+ */
++ (instancetype)vok_archiveFromMachOSection:(NSString *)sectionName
+                                      error:(NSError **)error;
+
+@end

--- a/Pod/ZZArchive+VOKMachOEmbedded.m
+++ b/Pod/ZZArchive+VOKMachOEmbedded.m
@@ -1,0 +1,27 @@
+//
+//  ZZArchive+VOKMachOEmbedded.m
+//  VOKEmbeddedTemplateTools
+//
+//  Created by Isaac Greenspan on 8/16/15.
+//  Copyright (c) 2015 Vokal. All rights reserved.
+//
+
+#import "ZZArchive+VOKMachOEmbedded.h"
+
+#import <NSData+VOKMachOEmbedded.h>
+
+@implementation ZZArchive (VOKMachOEmbedded)
+
++ (instancetype)vok_archiveFromMachOSection:(NSString *)sectionName
+                                      error:(NSError **)error
+{
+    NSData *data = [NSData vok_dataFromMachOSection:sectionName
+                                              error:error];
+    if (!data) {
+        return nil;
+    }
+    return [ZZArchive archiveWithData:data
+                                error:error];
+}
+
+@end

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # VOKEmbeddedTemplateTools
 
+Handle a zip file of mustache templates embedded into the Mach-O executable.
+
 [![CI Status](http://img.shields.io/travis/Isaac Greenspan/VOKEmbeddedTemplateTools.svg?style=flat)](https://travis-ci.org/Isaac Greenspan/VOKEmbeddedTemplateTools)
 [![Version](https://img.shields.io/cocoapods/v/VOKEmbeddedTemplateTools.svg?style=flat)](http://cocoapods.org/pods/VOKEmbeddedTemplateTools)
 [![License](https://img.shields.io/cocoapods/l/VOKEmbeddedTemplateTools.svg?style=flat)](http://cocoapods.org/pods/VOKEmbeddedTemplateTools)
@@ -7,9 +9,12 @@
 
 ## Usage
 
-To run the example project, clone the repo, and run `pod install` from the Example directory first.
+Includes:
+- a category on NSData for getting data embedded into the Mach-O executable (embedding done via "Other Linker Flags" `-sectcreate __TEXT __your_name "some_file_name"`)
+- a category on [ZipZap](https://github.com/pixelglow/zipzap)'s `ZZArchive` to load an archive from data embedded into the Mach-O executable
+- a [GRMustache](https://github.com/groue/GRMustache) `GRMustacheTemplateRepository` subclass that loads its templates from a `ZZArchive`
 
-## Requirements
+***NOTE:*** The Mach-O executable embedded data reading doesn't seem to compile when pods are set to use frameworks.
 
 ## Installation
 

--- a/VOKEmbeddedTemplateTools.podspec
+++ b/VOKEmbeddedTemplateTools.podspec
@@ -1,40 +1,38 @@
-#
-# Be sure to run `pod lib lint VOKEmbeddedTemplateTools.podspec' to ensure this is a
-# valid spec before submitting.
-#
-# Any lines starting with a # are optional, but their use is encouraged
-# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
-#
-
 Pod::Spec.new do |s|
   s.name             = "VOKEmbeddedTemplateTools"
   s.version          = "0.1.0"
-  s.summary          = "A short description of VOKEmbeddedTemplateTools."
+  s.summary          = "Handle a zip file of mustache templates embedded into the Mach-O executable."
 
-# This description is used to generate tags and improve search results.
-#   * Think: What does it do? Why did you write it? What is the focus?
-#   * Try to keep it short, snappy and to the point.
-#   * Write the description between the DESC delimiters below.
-#   * Finally, don't worry about the indent, CocoaPods strips it!  
   s.description      = <<-DESC
+                            Includes:
+                            - a category on NSData for getting data embedded into the Mach-O executable (embedding done via "Other Linker Flags" `-sectcreate __TEXT __your_name "some_file_name"`)
+                            - a category on [ZipZap](https://github.com/pixelglow/zipzap)'s `ZZArchive` to load an archive from data embedded into the Mach-O executable
+                            - a [GRMustache](https://github.com/groue/GRMustache) `GRMustacheTemplateRepository` subclass that loads its templates from a `ZZArchive`
+
+                            ***NOTE:*** The Mach-O executable embedded data reading doesn't seem to compile when pods are set to use frameworks.
                        DESC
 
-  s.homepage         = "https://github.com/<GITHUB_USERNAME>/VOKEmbeddedTemplateTools"
-  # s.screenshots     = "www.example.com/screenshots_1", "www.example.com/screenshots_2"
+  s.homepage         = "https://github.com/vokal/VOKEmbeddedTemplateTools"
   s.license          = 'MIT'
   s.author           = { "Isaac Greenspan" => "isaac.greenspan@vokal.io" }
-  s.source           = { :git => "https://github.com/<GITHUB_USERNAME>/VOKEmbeddedTemplateTools.git", :tag => s.version.to_s }
-  # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
+  s.source           = { :git => "https://github.com/vokal/VOKEmbeddedTemplateTools.git", :tag => s.version.to_s }
 
-  s.platform     = :ios, '7.0'
+  s.platform = :osx, '10.9'
   s.requires_arc = true
 
-  s.source_files = 'Pod/Classes/**/*'
-  s.resource_bundles = {
-    'VOKEmbeddedTemplateTools' => ['Pod/Assets/*.png']
-  }
+  s.subspec 'NSData+VOKMachOEmbedded' do |ss|
+    ss.source_files = 'Pod/NSData+VOKMachOEmbedded.{h,m}'
+  end
 
-  # s.public_header_files = 'Pod/Classes/**/*.h'
-  # s.frameworks = 'UIKit', 'MapKit'
-  # s.dependency 'AFNetworking', '~> 2.3'
+  s.subspec 'ZZArchive+VOKMachOEmbedded' do |ss|
+    ss.source_files = 'Pod/ZZArchive+VOKMachOEmbedded.{h,m}'
+    ss.dependency 'VOKEmbeddedTemplateTools/NSData+VOKMachOEmbedded'
+    ss.dependency 'zipzap', '~> 8.0.3'
+  end
+
+  s.subspec 'VOKZZArchiveTemplateRepository' do |ss|
+    ss.source_files = 'Pod/VOKZZArchiveTemplateRepository.{h,m}'
+    ss.dependency 'zipzap', '~> 8.0.3'
+    ss.dependency 'GRMustache', '~> 7.3.0'
+  end
 end


### PR DESCRIPTION
This is the initial implementation of the pod.  As it says in the README:

> Includes:
> - a category on NSData for getting data embedded into the Mach-O executable (embedding done via "Other Linker Flags" `-sectcreate __TEXT __your_name "some_file_name"`)
> - a category on [ZipZap](https://github.com/pixelglow/zipzap)'s `ZZArchive` to load an archive from data embedded into the Mach-O executable
> - a [GRMustache](https://github.com/groue/GRMustache) `GRMustacheTemplateRepository` subclass that loads its templates from a `ZZArchive`

The Example project has a zip archive of a trivial mustache template embedded into the executable and the test extracts it, renders it, and validates that it rendered as expected.

<s>I don't think Travis-CI is enabled for this repo (yet).</s> Done.

I kinda cheated and just pushed the Example project creation and pod install so that this PR would be more concise, but if anyone wants to look over all the other stuff committed to the repo, feel free.

@vokal/ios-developers Code review please?
